### PR TITLE
Add required Ruby version to gemspec

### DIFF
--- a/prius.gemspec
+++ b/prius.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.2"
+
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "rubocop", "~> 0.49.1"
 end


### PR DESCRIPTION
Bundler will automatically prevent installs on older Ruby versions if you do this.