### PR TITLE
Drop Ruby 2.2 & 2.3 support, add Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
     - type: cache-restore
       key: prius-bundler-{{ checksum "prius.gemspec" }}
 
-    - run: gem install bundler -v 1.17.3
+    - run: gem install bundler -v 2.0.1
 
     - run: bundle install --path vendor/bundle
 
@@ -33,14 +33,6 @@ references:
 
     - run: bundle exec rubocop
 jobs:
-  build-ruby22:
-    docker:
-      - image: ruby:2.2
-    steps: *steps
-  build-ruby23:
-    docker:
-      - image: ruby:2.3
-    steps: *steps
   build-ruby24:
     docker:
       - image: ruby:2.4
@@ -48,6 +40,10 @@ jobs:
   build-ruby25:
     docker:
       - image: ruby:2.5
+    steps: *steps
+  build-ruby26:
+    docker:
+      - image: ruby:2.6
     steps: *steps
   build-jruby91:
     docker:
@@ -58,8 +54,7 @@ workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby22
-      - build-ruby23
       - build-ruby24
       - build-ruby25
+      - build-ruby26
       - build-jruby91


### PR DESCRIPTION
Ruby 2.3 support was dropped here: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/