### PR TITLE
Prepare for v3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ jobs:
     docker:
       - image: ruby:2.6
     steps: *steps
+  build-ruby27:
+    docker:
+      - image: ruby:2.7
+    steps: *steps
   build-jruby91:
     docker:
       - image: jruby:9.1
@@ -57,4 +61,5 @@ workflows:
       - build-ruby24
       - build-ruby25
       - build-ruby26
+      - build-ruby27
       - build-jruby91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.0
+
+* Enforce Ruby 2.2 as minimum required version
+* Use CircleCI instead of Travis for CI builds
+* Add Dependabot support
+* Some development dependency updates
+
 # 2.0.0
 
 * Drop support for Ruby versions 1.9, 2.0, 2.1, and add support for 2.3 and 2.4

--- a/lib/prius/version.rb
+++ b/lib/prius/version.rb
@@ -1,3 +1,3 @@
 module Prius
-  VERSION = "2.0.0".freeze
+  VERSION = "3.0.0".freeze
 end


### PR DESCRIPTION
Most of the changes since 2.0.0 are dev dependency updates, but since we
have enforced a minimum Ruby version since, it is technically a breaking
change, hence a major version change.