### PR TITLE
Prepare for 4.0.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,6 @@ references:
 
     - run: bundle exec rubocop
 jobs:
-  build-ruby24:
-    docker:
-      - image: ruby:2.4
-    steps: *steps
-  build-ruby25:
-    docker:
-      - image: ruby:2.5
-    steps: *steps
   build-ruby26:
     docker:
       - image: ruby:2.6
@@ -49,17 +41,20 @@ jobs:
     docker:
       - image: ruby:2.7
     steps: *steps
-  build-jruby91:
+  build-ruby3:
     docker:
-      - image: jruby:9.1
+      - image: ruby:3
+    steps: *steps
+  build-jruby93:
+    docker:
+      - image: jruby:9.3
     steps: *steps
 
 workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby24
-      - build-ruby25
       - build-ruby26
       - build-ruby27
-      - build-jruby91
+      - build-ruby3
+      - build-jruby93

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - prius.gemspec
     - vendor/**/*
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.6
 
 # Limit lines to 80 characters.
 LineLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.0.0
+
+* Add support for Ruby 3.0
+* Enforce Ruby 2.6 as minimum required version
+* Drop support for Ruby 2.2, 2.3, 2.4, 2.5
+* Drop support for JRuby versions < 9.3.x (implicity enforced by C Ruby version 2.6 as minimum)
+
 # 3.0.0
 
 * Enforce Ruby 2.2 as minimum required version

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Environmentally-friendly application config for Ruby.
 
 [![Gem Version](https://badge.fury.io/rb/prius.svg)](http://badge.fury.io/rb/prius)
-[![Build Status](https://travis-ci.org/gocardless/prius.svg?branch=master)](https://travis-ci.org/gocardless/prius)
+[![Build Status](https://circleci.com/gh/gocardless/prius.svg?style=svg)](https://app.circleci.com/pipelines/github/gocardless/prius)
 
 Prius helps you guarantee that your environment variables are:
 

--- a/lib/prius.rb
+++ b/lib/prius.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "prius/registry"
 require "prius/railtie" if defined?(Rails)
 

--- a/lib/prius/errors.rb
+++ b/lib/prius/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prius
   class MissingValueError < StandardError; end
   class TypeMismatchError < StandardError; end

--- a/lib/prius/railtie.rb
+++ b/lib/prius/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prius
   class Railtie < Rails::Railtie
     config.before_configuration do

--- a/lib/prius/registry.rb
+++ b/lib/prius/registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "prius/errors"
 
 module Prius

--- a/lib/prius/version.rb
+++ b/lib/prius/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prius
-  VERSION = "3.0.0".freeze
+  VERSION = "4.0.0"
 end

--- a/prius.gemspec
+++ b/prius.gemspec
@@ -6,7 +6,7 @@ require 'prius/version'
 Gem::Specification.new do |spec|
   spec.name          = "prius"
   spec.version       = Prius::VERSION
-  spec.authors       = ["Harry Marr"]
+  spec.authors       = ["GoCardless Engineering"]
   spec.email         = ["engineering@gocardless.com"]
   spec.description   = %q{Environmentally-friendly config}
   spec.summary       = spec.description
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.2"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "rubocop", "~> 0.68.1"
-  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.0"
+  spec.add_development_dependency "rubocop", "~> 1.24"
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.5.1"
+  spec.add_development_dependency "rubocop-performance", "~> 1.13"
 end

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "prius/registry"
 
 describe Prius::Registry do


### PR DESCRIPTION
Add first class support for Ruby 3. Also, drop support for < 2.6, since they have reached end-of-life.

The reason we are choosing 2.6 (which has already reached EOL), and not 2.7, is because the CI build matrix has an entry for JRuby, implying that we support it. The latest version of JRuby (9.3.x) is only compatible with Ruby 2.6, and since this is a public gem we don't want to break integrations.