### PR TITLE
Add support for coercing to a date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Add support for coercing to a date.
+
 # 4.0.0
 
 * Add support for Ruby 3.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Prius helps you guarantee that your environment variables are:
 - **Present** - an exception is raised if an environment variable is missing,
   so you can hear about it as soon as your app boots.
 - **Valid** - an environment variable can be coerced to a desired type
-  (integer, boolean or string), and an exception will be raised if the value
+  (integer, boolean, string, or date), and an exception will be raised if the value
   doesn't match the type.
 
 ## Usage
@@ -60,7 +60,7 @@ If an environment variable can't be loaded, Prius will raise one of:
 | Param             | Default       | Description                                                                               |
 |-------------------|---------------|-------------------------------------------------------------------------------------------|
 | `required`        | `true`        | Flag to require the environment variable to have been set.                                |
-| `type`            | `:string`     | Type to coerce the environment variable to. Allowed values are `:string`, `:int` and `:bool`. |
+| `type`            | `:string`     | Type to coerce the environment variable to. Allowed values are `:string`, `:int`, `:bool`, and `:date`. |
 | `env_var`         | `name.upcase` | Name of the environment variable name (if different from the upcased `name`).             |
 
 #### Reading Environment Variables

--- a/lib/prius.rb
+++ b/lib/prius.rb
@@ -14,7 +14,7 @@ module Prius
   #                       omitted the uppercased form of `name` will be used.
   #           :type     - The Symbol type of the environment variable's value.
   #                       The value will be coerced to this type. Must be one
-  #                       of :string, :int, or :bool (default :string).
+  #                       of :string, :int, :bool, or :date (default :string).
   #           :required - A Boolean indicating whether the value must be
   #                       present in the environment. If true, a
   #                       MissingValueError exception will be raised if the

--- a/lib/prius/registry.rb
+++ b/lib/prius/registry.rb
@@ -22,6 +22,7 @@ module Prius
                         when :string then load_string(env_var, required)
                         when :int    then load_int(env_var, required)
                         when :bool   then load_bool(env_var, required)
+                        when :date   then load_date(env_var, required)
                         else raise ArgumentError, "Invalid type #{type}"
                         end
     end
@@ -61,6 +62,15 @@ module Prius
       return false if %w[no n false f 0].include?(value)
 
       raise TypeMismatchError, "'#{name}' value '#{value}' is not a boolean"
+    end
+
+    def load_date(name, required)
+      value = load_string(name, required)
+      return nil if value.nil?
+
+      Date.parse(value)
+    rescue ArgumentError
+      raise TypeMismatchError, "'#{name}' value '#{value}' is not a date"
     end
   end
 end

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -3,7 +3,15 @@
 require "prius/registry"
 
 describe Prius::Registry do
-  let(:env) { { "NAME" => "Harry", "AGE" => "25", "ALIVE" => "yes" } }
+  let(:env) do
+    {
+      "NAME" => "Harry",
+      "AGE" => "25",
+      "ALIVE" => "yes",
+      "BORN" => "2022-09-02",
+      "INVALID_DATE" => "2022-02-99"
+    }
+  end
   let(:registry) { Prius::Registry.new(env) }
 
   describe "#load" do
@@ -68,6 +76,34 @@ describe Prius::Registry do
       context "given a non-boolean value" do
         it "blows up" do
           expect { registry.load(:name, type: :bool) }.
+            to raise_error(Prius::TypeMismatchError)
+        end
+      end
+    end
+
+    context "when specifying :date as the type" do
+      context "given a date value" do
+        it "doesn't blow up" do
+          expect { registry.load(:born, type: :date) }.to_not raise_error
+        end
+
+        it "stores a date" do
+          registry.load(:born, type: :date)
+          expect(registry.get(:born)).to be_a(Date)
+          expect(registry.get(:born)).to eq(Date.parse(env["BORN"]))
+        end
+      end
+
+      context "given an invalid date value" do
+        it "blows up" do
+          expect { registry.load(:invalid_date, type: :date) }.
+            to raise_error(Prius::TypeMismatchError)
+        end
+      end
+
+      context "given a non-date value" do
+        it "blows up" do
+          expect { registry.load(:name, type: :date) }.
             to raise_error(Prius::TypeMismatchError)
         end
       end


### PR DESCRIPTION
Currently, if you want to pass a date in an env var, you need to
interpret it as a string and parse that string yourself.  This means
you need to handle validation failures at runtime, which is less than
ideal.  We recently hit this in payments-service.

By adding a date type here, we can validate date env vars in the same
way as bool and int vars.