### PR TITLE
Ensure `Prius#load` raises an error when unexpected options are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0
+
+* Ensure Prius#load raises an error when unexpected options are passed
+
 # 4.1.0
 
 * Add support for coercing to a date.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Environment variables need to be loaded into the Prius registry before being
 used. Typically this is done in an initialiser.
 
 ```ruby
-Prius.load(name, options = {})
+Prius.load(name, **options)
 ```
 
 If an environment variable can't be loaded, Prius will raise one of:

--- a/lib/prius.rb
+++ b/lib/prius.rb
@@ -25,8 +25,8 @@ module Prius
   # Raises a MissingValueError for required values that are missing.
   # Raises a TypeMismatchError if a value can't be coerced to the given `type`.
   # Raises an ArgumentError if an invalid `type` is provided.
-  def self.load(name, options = {})
-    registry.load(name, options)
+  def self.load(name, **options)
+    registry.load(name, **options)
   end
 
   # Fetch a value from the registry.

--- a/lib/prius/registry.rb
+++ b/lib/prius/registry.rb
@@ -14,10 +14,8 @@ module Prius
     end
 
     # See Prius.load for documentation.
-    def load(name, options = {})
-      env_var = options.fetch(:env_var, name.to_s.upcase)
-      type = options.fetch(:type, :string)
-      required = options.fetch(:required, true)
+    def load(name, env_var: nil, type: :string, required: true)
+      env_var = env_var.nil? ? name.to_s.upcase : env_var
       @registry[name] = case type
                         when :string then load_string(env_var, required)
                         when :int    then load_int(env_var, required)

--- a/lib/prius/version.rb
+++ b/lib/prius/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prius
-  VERSION = "4.1.0"
+  VERSION = "5.0.0"
 end

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -15,6 +15,13 @@ describe Prius::Registry do
   let(:registry) { Prius::Registry.new(env) }
 
   describe "#load" do
+    context "given an invalid option" do
+      it "raises an error" do
+        expect { registry.load(:age, unsupported_option: :foo) }.
+          to raise_error(ArgumentError)
+      end
+    end
+
     context "given a name that's present in the environment" do
       it "doesn't blow up" do
         expect { registry.load(:name) }.to_not raise_error


### PR DESCRIPTION
This makes it such that extraneous arguments passed in to `Prius#load` 
raise an ArgumentError rather than getting silently ignored.

### Why?

In a recent incident, we noticed that `Prius#load` was getting invoked with a 
`default: ` keyword argument which was getting silently ignored. 

Unfortunately, we were assuming that the envvar would be set to the value of 
the `default` argument, which wasn't the case.

This, in combination with the fact that the envvar was set to `required: false` 
ended up making it such that the value was totally missing without us realizing. 