### PR TITLE
Downcase boolean strings when comparing boolean env types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Drop support for Ruby 2.6 and 2.7.
 - Add support for Ruby 3.2 and 3.3.
+- Downcase boolean values when checking for truthiness.
 
 # 5.0.0
 

--- a/lib/prius/registry.rb
+++ b/lib/prius/registry.rb
@@ -57,6 +57,8 @@ module Prius
     def load_bool(name, required)
       value = load_string(name, required)
       return nil if value.nil?
+
+      value = value.downcase
       return true if %w[yes y true t 1].include?(value)
       return false if %w[no n false f 0].include?(value)
 

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe Prius::Registry do
     {
       "NAME" => "Harry",
       "AGE" => "25",
-      "ALIVE" => "yes",
+      "ALIVE" => "Yes",
       "BORN" => "2022-09-02",
       "INVALID_DATE" => "2022-02-99",
-      "CAPITALISED_BOOLEAN" => "TRUE",
     }
   end
   let(:registry) { described_class.new(env) }
@@ -78,17 +77,6 @@ RSpec.describe Prius::Registry do
         it "stores an boolean" do
           registry.load(:alive, type: :bool)
           expect(registry.get(:alive)).to be_a(TrueClass)
-        end
-      end
-
-      context "when capitalised" do
-        it "doesn't blow up" do
-          expect { registry.load(:capitalised_boolean, type: :bool) }.to_not raise_error
-        end
-
-        it "stores an boolean" do
-          registry.load(:capitalised_boolean, type: :bool)
-          expect(registry.get(:capitalised_boolean)).to be_a(TrueClass)
         end
       end
 

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Prius::Registry do
       "ALIVE" => "yes",
       "BORN" => "2022-09-02",
       "INVALID_DATE" => "2022-02-99",
+      "CAPITALISED_BOOLEAN" => "TRUE",
     }
   end
   let(:registry) { described_class.new(env) }
@@ -77,6 +78,17 @@ RSpec.describe Prius::Registry do
         it "stores an boolean" do
           registry.load(:alive, type: :bool)
           expect(registry.get(:alive)).to be_a(TrueClass)
+        end
+      end
+
+      context "when capitalised" do
+        it "doesn't blow up" do
+          expect { registry.load(:capitalised_boolean, type: :bool) }.to_not raise_error
+        end
+
+        it "stores an boolean" do
+          registry.load(:capitalised_boolean, type: :bool)
+          expect(registry.get(:capitalised_boolean)).to be_a(TrueClass)
         end
       end
 


### PR DESCRIPTION
Allows for configuration such as `True` or `TRUE`
