### PR TITLE
Add support for loading a datetime value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.0 - 2024-06-27
+
+- Add support for loading a datetime value.
+
 # 6.0.0 - 2024-01-09
 
 - Drop support for Ruby 2.6 and 2.7.

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "gc_ruboconfig", "~> 4.4"
+  gem "gc_ruboconfig", "~> 5.0"
   gem 'pry'
   gem "rspec", "~> 3.12"
   gem "rspec-github", "~> 2.4.0"

--- a/lib/prius/registry.rb
+++ b/lib/prius/registry.rb
@@ -18,10 +18,11 @@ module Prius
     def load(name, env_var: nil, type: :string, required: true)
       env_var = name.to_s.upcase if env_var.nil?
       @registry[name] = case type
-                        when :string then load_string(env_var, required)
-                        when :int    then load_int(env_var, required)
-                        when :bool   then load_bool(env_var, required)
-                        when :date   then load_date(env_var, required)
+                        when :string   then load_string(env_var, required)
+                        when :int      then load_int(env_var, required)
+                        when :bool     then load_bool(env_var, required)
+                        when :date     then load_date(env_var, required)
+                        when :datetime then load_datetime(env_var, required)
                         else raise ArgumentError, "Invalid type #{type}"
                         end
     end
@@ -72,6 +73,15 @@ module Prius
       Date.parse(value)
     rescue ArgumentError
       raise TypeMismatchError, "'#{name}' value '#{value}' is not a date"
+    end
+
+    def load_datetime(name, required)
+      value = load_string(name, required)
+      return nil if value.nil?
+
+      DateTime.parse(value)
+    rescue ArgumentError
+      raise TypeMismatchError, "'#{name}' value '#{value}' is not a datetime"
     end
   end
 end

--- a/lib/prius/version.rb
+++ b/lib/prius/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prius
-  VERSION = "6.0.0"
+  VERSION = "6.1.0"
 end

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Prius::Registry do
       "ALIVE" => "Yes",
       "BORN" => "2022-09-02",
       "INVALID_DATE" => "2022-02-99",
+      "HELIUM_RELEASE_DATETIME" => "2024-01-31 00:00 UTC",
+      "INVALID_RELEASE_DATETIME" => "2024-01-31 00:99 UTC",
     }
   end
   let(:registry) { described_class.new(env) }
@@ -111,6 +113,34 @@ RSpec.describe Prius::Registry do
       context "given a non-date value" do
         it "blows up" do
           expect { registry.load(:name, type: :date) }.
+            to raise_error(Prius::TypeMismatchError)
+        end
+      end
+    end
+
+    context "when specifying :datetime as the type" do
+      context "given a datetime value" do
+        it "doesn't blow up" do
+          expect { registry.load(:helium_release_datetime, type: :datetime) }.to_not raise_error
+        end
+
+        it "stores a datetime" do
+          registry.load(:helium_release_datetime, type: :datetime)
+          expect(registry.get(:helium_release_datetime)).to be_a(DateTime)
+          expect(registry.get(:helium_release_datetime)).to eq(DateTime.parse(env["HELIUM_RELEASE_DATETIME"]))
+        end
+      end
+
+      context "given an invalid date value" do
+        it "blows up" do
+          expect { registry.load(:invalid_release_datetime, type: :datetime) }.
+            to raise_error(Prius::TypeMismatchError)
+        end
+      end
+
+      context "given a non-date value" do
+        it "blows up" do
+          expect { registry.load(:name, type: :datetime) }.
             to raise_error(Prius::TypeMismatchError)
         end
       end


### PR DESCRIPTION
Currently, there is no way to pass a datetime environment variable. The closest thing we have is the `:date` type which one can only use for dates. We have recently hit a use case where it would be ideal to support loading `:datetime` environment variables (we want to set a date and time after which some business logic changes).

This PR adds just that + the validation required to load a datetime value correctly.