### PR TITLE
[RFC] Support default value for optional environment variables

### DIFF
--- a/lib/prius/errors.rb
+++ b/lib/prius/errors.rb
@@ -4,4 +4,5 @@ module Prius
   class MissingValueError < StandardError; end
   class TypeMismatchError < StandardError; end
   class UndeclaredNameError < StandardError; end
+  class InvalidLoadError < StandardError; end
 end

--- a/lib/prius/registry.rb
+++ b/lib/prius/registry.rb
@@ -15,9 +15,14 @@ module Prius
     end
 
     # See Prius.load for documentation.
-    def load(name, env_var: nil, type: :string, required: true)
+    def load(name, env_var: nil, type: :string, required: true, default: nil)
       env_var = name.to_s.upcase if env_var.nil?
-      value = load_value(env_var, required)
+
+      if required && !default.nil?
+        raise InvalidLoadError, "required config value #{env_var} cannot have default value"
+      end
+
+      value = load_value(env_var, required, default)
       @registry[name] = case type
                         when :string then value
                         when :int    then parse_int(env_var, value)
@@ -36,10 +41,10 @@ module Prius
 
     private
 
-    def load_value(name, required)
+    def load_value(name, required, default)
       @env.fetch(name)
     rescue KeyError
-      return nil unless required
+      return default unless required
 
       raise MissingValueError, "config value '#{name}' not present"
     end

--- a/spec/prius/registry_spec.rb
+++ b/spec/prius/registry_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Prius::Registry do
       it "doesn't blow up" do
         expect { registry.load(:name) }.to_not raise_error
       end
+
+      context "but also a default value" do
+        it "raises an error" do
+          expect { registry.load(:name, default: "foo") }.
+            to raise_error(Prius::InvalidLoadError)
+        end
+      end
     end
 
     context "given a name that's not present in the environment" do
@@ -38,6 +45,14 @@ RSpec.describe Prius::Registry do
         it "doesn't blow up" do
           expect { registry.load(:slogan, required: false) }.to_not raise_error
         end
+
+        context "when a default value is provided" do
+          it "doesn't blow up" do
+            expect do
+              registry.load(:slogan, required: false, default: "GO GO GO")
+            end.to_not raise_error
+          end
+        end
       end
     end
 
@@ -45,6 +60,14 @@ RSpec.describe Prius::Registry do
       it "blows up" do
         expect { registry.load(:name, type: :lightsabre) }.
           to raise_error(ArgumentError)
+      end
+    end
+
+    # TODO: Decide if default values should be strings or of the parsed type
+    context "when specifying a default for a non-string type" do
+      it "doesn't blow up" do
+        expect { registry.load(:blah, type: :int, required: false, default: "56") }.
+          to_not raise_error
       end
     end
 
@@ -74,7 +97,7 @@ RSpec.describe Prius::Registry do
           expect { registry.load(:alive, type: :bool) }.to_not raise_error
         end
 
-        it "stores an boolean" do
+        it "stores a boolean" do
           registry.load(:alive, type: :bool)
           expect(registry.get(:alive)).to be_a(TrueClass)
         end
@@ -133,11 +156,19 @@ RSpec.describe Prius::Registry do
       end
     end
 
-    context "given a nillable name that has been loaded" do
+    context "given a nilable name that has been loaded" do
       before { registry.load(:lightsabre, required: false) }
 
       it "returns nil" do
         expect(registry.get(:lightsabre)).to be_nil
+      end
+
+      context "with a default" do
+        before { registry.load(:lightsabre, required: false, default: "blue") }
+
+        it "returns the default" do
+          expect(registry.get(:lightsabre)).to eq("blue")
+        end
       end
     end
   end


### PR DESCRIPTION
Prius helps us ensure that our application always boots with the
required state. However in large applications with multiple contributors,
this can cause a configuration error in an unrelated component to break
the entire application.

Providing a default value allows contributors to safely introduce new
configuration without worrying if the application breaks. For example:
```ruby
Prius.get(:my_worker_pool, type: int, required: false, default: 0)
```

It also means that boolean flags that are optional can be made to have a
default value of `true` or `false`, rather than `nil`.

**Note**: This change _does not_ allow you to specify a default value for
required config, for obvious reasons.